### PR TITLE
Catch errors on the underlying socket

### DIFF
--- a/WebSocket.js
+++ b/WebSocket.js
@@ -68,6 +68,10 @@ class WebSocket extends events.EventEmitter {
     this._handleDataFrames()
 
     this.on('error', unhandledErrorListener.bind(this))
+
+    this._socket.on('error', error => {
+      this.emit('error', error)
+    })
   }
 
   /**

--- a/_internal/ServerWebSocket.js
+++ b/_internal/ServerWebSocket.js
@@ -18,6 +18,10 @@ class ServerWebsocket extends events.EventEmitter {
     this._socket = socket
 
     this.on('error', unhandledErrorListener.bind(this))
+
+    this._socket.on('error', error => {
+      this.emit('error', error)
+    })
   }
 
   /**


### PR DESCRIPTION
Adds listeners for the "error" event to the underlying socket  `_socket` for WebSocket and ServerWebSocket classes.