### PR TITLE
Continuation frames permessage deflate

### DIFF
--- a/WebSocket.js
+++ b/WebSocket.js
@@ -1,5 +1,5 @@
 /**
- * presidium-websocket v0.3.1
+ * presidium-websocket v0.3.2
  * https://github.com/richytong/presidium-websocket
  * (c) 2025 Richard Tong
  * presidium-websocket may be freely distributed under the MIT license.

--- a/WebSocketSecureServer.js
+++ b/WebSocketSecureServer.js
@@ -1,5 +1,5 @@
 /**
- * presidium-websocket v0.3.1
+ * presidium-websocket v0.3.2
  * https://github.com/richytong/presidium-websocket
  * (c) 2025 Richard Tong
  * presidium-websocket may be freely distributed under the MIT license.

--- a/WebSocketServer.js
+++ b/WebSocketServer.js
@@ -11,7 +11,6 @@ const crypto = require('crypto')
 const events = require('events')
 const decodeWebSocketFrame = require('./_internal/decodeWebSocketFrame')
 const ServerWebSocket = require('./_internal/ServerWebSocket')
-const unhandledErrorListener = require('./_internal/unhandledErrorListener')
 const LinkedList = require('./_internal/LinkedList')
 const __ = require('./_internal/placeholder')
 const curry3 = require('./_internal/curry3')
@@ -123,8 +122,6 @@ class WebSocketServer extends events.EventEmitter {
     this._server.on('upgrade', this._handleUpgrade.bind(this))
 
     this.connections = []
-
-    this.on('error', unhandledErrorListener.bind(this))
 
   }
 
@@ -280,10 +277,10 @@ class WebSocketServer extends events.EventEmitter {
 
     while (chunks.length > 0) { // process data frames
       let chunk = chunks.shift()
-      let decodeResult = decodeWebSocketFrame.call(this, chunk, websocket._perMessageDeflate)
+      let decodeResult = decodeWebSocketFrame.call(websocket, chunk, websocket._perMessageDeflate)
       while (decodeResult == null && chunks.length > 0) {
         chunk = Buffer.concat([chunk, chunks.shift()])
-        decodeResult = decodeWebSocketFrame.call(this, chunk, websocket._perMessageDeflate)
+        decodeResult = decodeWebSocketFrame.call(websocket, chunk, websocket._perMessageDeflate)
       }
       if (decodeResult == null) {
         chunks.prepend(chunk)

--- a/WebSocketServer.js
+++ b/WebSocketServer.js
@@ -1,5 +1,5 @@
 /**
- * presidium-websocket v0.3.1
+ * presidium-websocket v0.3.2
  * https://github.com/richytong/presidium-websocket
  * (c) 2025 Richard Tong
  * presidium-websocket may be freely distributed under the MIT license.

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 /**
- * presidium-websocket v0.3.1
+ * presidium-websocket v0.3.2
  * https://github.com/richytong/presidium-websocket
  * (c) 2025 Richard Tong
  * presidium-websocket may be freely distributed under the MIT license.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "presidium-websocket",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Presidium WebSocket client and server for Node.js",
   "author": "Richard Tong",
   "license": "MIT",


### PR DESCRIPTION
On send, compress payload and THEN split into fragments (continuation frames).

On receive, enforce this language from the compression [RFC](https://datatracker.ietf.org/doc/html/rfc7692):
```
  An endpoint MUST NOT set the "Per-Message Compressed" bit of control
  frames and non-first fragments (continuation frames) of a data message.
```

resolves https://github.com/richytong/presidium-websocket/issues/4