### PR TITLE
fix: url wasn't including path, search params, and hash

### DIFF
--- a/WebSocket.js
+++ b/WebSocket.js
@@ -60,6 +60,8 @@ class WebSocket extends events.EventEmitter {
       hostname: parsedUrl.hostname,
       protocol: parsedUrl.protocol,
       pathname: parsedUrl.pathname,
+      search: parsedUrl.search,
+      hash: parsedUrl.hash
     }
     if (parsedUrl.port.length > 0) {
       this.url.port = Number(parsedUrl.port)
@@ -164,8 +166,9 @@ class WebSocket extends events.EventEmitter {
    */
   _requestUpgrade() {
     const key = crypto.randomBytes(16).toString('base64')
+
     this._socket.write(
-      `GET ${this.url.pathname} HTTP/1.1\r\nHost: ${this.url.hostname}:${this.url.port}\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: ${key}\r\nSec-WebSocket-Version: 13\r\n${this._offerPerMessageDeflate ? 'Sec-WebSocket-Extensions: permessage-deflate; client_max_window_bits\r\n' : ''}\r\n`
+      `GET ${this.url.pathname}${this.url.search}${this.url.hash} HTTP/1.1\r\nHost: ${this.url.hostname}:${this.url.port}\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: ${key}\r\nSec-WebSocket-Version: 13\r\n${this._offerPerMessageDeflate ? 'Sec-WebSocket-Extensions: permessage-deflate; client_max_window_bits\r\n' : ''}\r\n`
     )
   }
 

--- a/test.js
+++ b/test.js
@@ -2407,4 +2407,33 @@ describe('WebSocket.Server, WebSocket', () => {
 
     await sleep(100)
   })
+
+  it('WebSocket connects to WebSocketServer at a path with query parameters and hash', async () => {
+    let didConnect = false
+    const server = new WebSocket.Server()
+    server.on('connection', (websocket, request) => {
+      assert.equal(request.url, '/test-path?a=1&b=%202#anchor')
+      didConnect = true
+      websocket.close()
+    })
+    server.listen(7357)
+
+    let resolve
+    const promise = new Promise(_resolve => {
+      resolve = _resolve
+    })
+
+    const websocket = new WebSocket('ws://localhost:7357/test-path?a=1&b=%202#anchor')
+
+    websocket.on('close', () => {
+      resolve()
+    })
+
+    await promise
+
+    assert(didConnect)
+    server.close()
+
+    await sleep(100)
+  })
 })


### PR DESCRIPTION
Urls with path, search params, and hash were breaking. Example url:

```
wss://transcribestreaming.us-east-1.amazonaws.com:8443/stream-transcription-websocket?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=...
```